### PR TITLE
Make waiting for script call to finish optional

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -8,5 +8,7 @@ extern "C" {
 extern std::string script_path;
 /* Name of the script (without the leading directory). */
 extern std::string script_name;
+/* Wait for script to finish executing */
+extern bool script_wait;
 
 }

--- a/src/load.cc
+++ b/src/load.cc
@@ -11,6 +11,8 @@ using namespace isc::data;
 std::string script_path;
 /* Name of the script (without the leading directory). */
 std::string script_name;
+/* Wait for script to finish executing */
+bool script_wait;
 
 extern "C" {
 
@@ -26,6 +28,16 @@ int load(LibraryHandle& handle) {
     }
     script_path = script->stringValue();
     script_name = script_path.substr(script_path.find_last_of('/') + 1);
+
+    ConstElementPtr wait = handle.getParameter("wait");
+    if (!wait) {
+       script_wait = true;
+    } else if (wait->getType() != Element::boolean) {
+       LOG_ERROR(runscript_logger, RUNSCRIPT_MISTYPED_PARAM).arg("wait");
+       return 1;
+    } else {
+       script_wait = wait->boolValue();
+    }
 
     return 0;
 }

--- a/src/runscript.cc
+++ b/src/runscript.cc
@@ -37,20 +37,24 @@ int run_script(std::string arg0, std::vector<std::string> env)
         /* This only exists the child, not Kea itself. */
         exit(EXIT_FAILURE);
     } else {
-        /* Parent process */
-        LOG_DEBUG(runscript_logger, 50, RUNSCRIPT_WAITING_SCRIPT);
-        ret = wait(&wstatus);
-        if (ret == -1) {
-            LOG_ERROR(runscript_logger, RUNSCRIPT_WAITPID_FAILED).arg(strerror(errno));
-            return -1;
+        if (script_wait) {
+            /* Parent process */
+            LOG_DEBUG(runscript_logger, 50, RUNSCRIPT_WAITING_SCRIPT);
+            ret = wait(&wstatus);
+            if (ret == -1) {
+                LOG_ERROR(runscript_logger, RUNSCRIPT_WAITPID_FAILED).arg(strerror(errno));
+                return -1;
+            }
+            /* Get exit code */
+            if (WIFEXITED(wstatus))
+                exitcode = WEXITSTATUS(wstatus);
+            else
+                /* By default, assume everything worked well */
+                exitcode = 0;
+            return exitcode;
+        } else {
+            return 0;
         }
-        /* Get exit code */
-        if (WIFEXITED(wstatus))
-            exitcode = WEXITSTATUS(wstatus);
-        else
-            /* By default, assume everything worked well */
-            exitcode = 0;
-        return exitcode;
     }
 }
 


### PR DESCRIPTION
Adds a hook script parameter `wait` (defaults to `true`) to optionally not wait for the called script to finish. As the called script doesn't alter the behavior of the DHCP server it doesn't really make sense to wait for it to finish in a lot of cases, speeding up DHCP processing.

The parameter is optional and will maintain the old behavior of waiting if not defined.

Example configuration:
```
    "hooks-libraries": [
      {
        "library": "/usr/local/lib/hooks/kea-hook-runscript.so",
        "parameters": {
          "script": "/usr/local/etc/kea/hooks/napi.sh",
          "wait": false
        }
      }
    ]
```