### PR TITLE
Fix dhcp4 mac address retrieve method

### DIFF
--- a/src/callouts.cc
+++ b/src/callouts.cc
@@ -39,7 +39,7 @@ void extract_pkt4(std::vector<std::string>& env, const std::string envprefix, co
     env.push_back(envprefix + "INTERFACE=" + pkt4->getIface());
     env.push_back(envprefix + "IFINDEX=" + std::to_string(pkt4->getIndex()));
     /* Hardware address */
-    HWAddrPtr hwaddr = pkt4->getMAC(HWAddr::HWADDR_SOURCE_ANY);
+    HWAddrPtr hwaddr = pkt4->getHWAddr();
     if (hwaddr) {
         env.push_back(envprefix + "HWADDR=" + hwaddr->toText(false));
         env.push_back(envprefix + "HWADDR_TYPE=" + std::to_string(hwaddr->htype_));


### PR DESCRIPTION
The getMAC method of pkt4 seems to retrieve the mac of the packet sender which is not the client MAC if a dhcp-relay is used.

The getHWAddr seems to be the method used in the KEA server (it's used in src/bin/dhcp4/dhcp4_srv.cc of the KEA 1.6.1 sources) and return the expected MAC address.

I test this patch with KEA 1.6.1 sources and hook release v1.3.1, it work as expected.
Without this path the MAC address in KEA_QUERY4_HWADDR is the MAC address of my default gateway, because the packet is forwarded from a dhcp-relay.